### PR TITLE
cmake tweaks to automate some decisions and such

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Top Level CMake file for XTOOLS.
 
-cmake_minimum_required(VERSION 3.9.6)
+cmake_minimum_required(VERSION 3.9.6...4.99)
+
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to MinSizeRel")
@@ -41,8 +42,53 @@ set(UNIX_LIBDIR_SUFFIX "" CACHE STRING "Define suffix of library directory name 
 if(CMAKE_CROSSCOMPILING)
   message(STATUS "*Top Level* Cross compiling for ${CMAKE_SYSTEM_VERSION}")
 else()
-  message(STATUS "*Top Level* native build version ${CMAKE_SYSTEM_VERSION}")
+  message(STATUS "*Top Level* native build version ${CMAKE_HOST_SYSTEM_VERSION}")
 endif()
+
+# Include the mandatory compiler flag check module
+include(CheckCXXCompilerFlag)
+
+# Define the Darwin/macOS architectures you want to test
+# Common 64-bit: x86_64, arm64
+# Common 32-bit: i386, ppc
+set(TARGET_ARCHS "x86_64" "i386" "arm64" "arm64e" "arm64_32" "ppc64" "ppc")
+
+foreach(ARCH ${TARGET_ARCHS})
+    # Create a unique variable name for each architecture check result
+    set(FLAG_VAR "COMPILER_SUPPORTS_${ARCH}")
+    
+    # Temporarily force the compiler to try building with this specific architecture flag
+    # CMake 3.9 requires the flags to be passed exactly as the compiler expects them
+    set(CMAKE_REQUIRED_FLAGS "-arch ${ARCH}")
+    
+    # Run a test compilation using an empty check flag (we are testing CMAKE_REQUIRED_FLAGS)
+    # The third argument stores the result (TRUE/FALSE) in our dynamic variable name
+    check_cxx_compiler_flag("" ${FLAG_VAR})
+    
+    # Evaluate the result
+    if(${FLAG_VAR})
+        message(STATUS "Compiler supports architecture: ${ARCH}")
+    else()
+        message(STATUS "Compiler DOES NOT support architecture: ${ARCH}")
+    endif()
+    
+    # Clean up the required flags variable for the next loop iteration
+    unset(CMAKE_REQUIRED_FLAGS)
+endforeach()
+
+
+# A pointer size of 8 bytes means 64-bit architecture
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(STATUS "Default compiler output is 64-bit")
+    set(XTOOLS_HOST_IS_64B YES CACHE BOOL "host native bitwidth")
+# A pointer size of 4 bytes means 32-bit architecture
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    message(STATUS "Default compiler output is 32-bit")
+    set(XTOOLS_HOST_IS_64B NO CACHE BOOL "host native bitwidth")
+else()
+    message(STATUS "Unknown bitness (Size of pointer: ${CMAKE_SIZEOF_VOID_P} bytes)")
+endif()
+
 
 if(FALSE AND XTOOLS_LTO_PATH AND
    EXISTS ${XTOOLS_LTO_PATH}/include/llvm-c/lto.h AND

--- a/cctools/CMakeLists.txt
+++ b/cctools/CMakeLists.txt
@@ -10,7 +10,12 @@ set(CCTOOLS_VERSION_NUM 855)
 add_definitions(-DALLOW_64BIT_LEB_ON_32B_TARGET=1 -DIN_CCTOOLS)
 
 option(CCTOOLS_EFITOOLS  "Build efitools as part of cctools" OFF)
-option(CCTOOLS_LD_CLASSIC  "Build ld_classic as part of cctools" ON)
+
+if ( COMPILER_SUPPORTS_i386 OR COMPILER_SUPPORTS_ppc )
+  option(CCTOOLS_LD_CLASSIC  "Build ld_classic as part of cctools" ON)
+else()
+  option(CCTOOLS_LD_CLASSIC  "Build ld_classic as part of cctools" OFF)
+endif()
 
 configure_file (
   "${CMAKE_SOURCE_DIR}/cctools/cctools_version.c.in"


### PR DESCRIPTION
Some cmake ideas for you to consider.

Tested and working to set up all the defaults properly on arm64 Tahoe.
To be further tested on other systems and when cross-compiling.

1. add cmake version range to suppress warning
2. make clear the difference between CMAKE_HOST_SYSTEM_VERSION and CMAKE_SYSTEM_VERSION
3. test compiler for default 64Bit and set XTOOLS_HOST_IS_64B appropriately
4. test compiler for 32 bit compiling support and set CCTOOLS_LD_CLASSIC appropriately